### PR TITLE
tooling: clean-rem-tags script and Makefile integration

### DIFF
--- a/.github/actions/alpine-pandoc-hugo/Dockerfile
+++ b/.github/actions/alpine-pandoc-hugo/Dockerfile
@@ -3,4 +3,8 @@ FROM pandoc/latex:latest
 COPY install-packages.sh /root/install-packages.sh
 RUN /root/install-packages.sh && rm -rf /root/install-packages.sh
 
+RUN apk --no-cache add ruby git
+COPY delete-script.rb /opt/delete-script.rb
+RUN chmod +x /opt/delete-script.rb
+
 ENTRYPOINT ["sh", "-c"]

--- a/.github/actions/alpine-pandoc-hugo/delete-script.rb
+++ b/.github/actions/alpine-pandoc-hugo/delete-script.rb
@@ -1,0 +1,122 @@
+#!/usr/bin/env ruby
+
+# delete-script.rb
+# Usage: ./delete-script.rb [dir]
+#
+# Args:
+# dir [Optional]: directory to recursively process. Default: .
+#
+# Recursively opens all '.md' files in `dir`.
+# If it finds a matching pair of `<!-- REM` `REM -->` markers,
+# it deletes the block of text containing the markers,
+# adds the file to git's stage area and creates a commit
+# with the message `rm(<file path>): <text behind opening REM marker>`.
+#
+# You usually want to execute this in the markdown directory without any arguments.
+# (Or pass 'markdown' to this script)
+#
+# Alternatively, simply use the makefile in the root of this repo.
+
+START_MARKER = '<!-- REM'
+END_MARKER = 'REM -->'
+FILE_EXT = ".md"
+
+class RemSyntaxError < StandardError
+end
+
+def remove_block(path, start_line, message, end_line, initial_path)
+    scope = path.delete_suffix(File.extname path)
+    if initial_path.end_with?("/")
+        scope = scope.delete_prefix(initial_path)
+    else
+        scope = scope.delete_prefix(initial_path + "/")
+    end
+
+    commit = "rm(#{scope}): #{message}"
+
+        puts "Deleting #{path}:#{start_line + 1} - #{path}:#{end_line + 1} with commit message '#{commit}'"
+
+        lines = IO.readlines(path)
+
+    File.open(path, mode: "w") do |f|
+        lines.each_with_index do |line, index|
+            if index < start_line || index > end_line
+                f.write(line)
+            end
+        end
+    end
+
+    system("git add '#{path}'", exception: true)
+    system("git commit -m '#{commit}'", exception: true)
+end
+
+def process_file_once(path, initial_path)
+  start_line = false
+  message = ""
+  end_line = false
+
+  IO.readlines(path).each_with_index do |line, index|
+
+    if !start_line && line.start_with?(START_MARKER)
+      start_line = index
+      message = line.delete_prefix(START_MARKER + "").strip()
+    elsif start_line
+      if line.start_with?(END_MARKER)
+        end_line = index
+      elsif line.start_with?(START_MARKER)
+        raise RemSyntaxError, "Found nested '#{START_MARKER}' at #{path}:#{index + 1}! (outer block starts at L#{start_line + 1})"
+      end
+    elsif line.start_with?(END_MARKER)
+      raise RemSyntaxError, "Found '#{END_MARKER}' without corresponding '#{START_MARKER}' at #{path}:#{index + 1}"
+    end
+
+    break if end_line
+  end
+
+  if start_line && !end_line
+    raise RemSyntaxError, "Missing '#{END_MARKER}' at #{path}:EOF! (block starts at L#{start_line + 1})"
+  elsif start_line && end_line
+    remove_block(path, start_line, message, end_line, initial_path)
+    return true
+  else
+    return false
+  end
+end
+
+def process_file_all(file, initial_path)
+  # process file until there are no more blocks to be removed
+  deleted = true
+  while deleted
+      deleted = process_file_once(file, initial_path)
+  end
+end
+
+def process_dir(path, initial_path)
+  errors = []
+
+  Dir.each_child(path) do |entry|
+    entry_path = File.join(path, entry)
+
+    if Dir.exists?(entry_path)
+      errors += process_dir(entry_path, initial_path)
+    elsif File.file?(entry_path) && File.extname(entry_path) == FILE_EXT
+      begin
+        process_file_all(entry_path, initial_path)
+      rescue => e
+        errors << e
+      end
+    end
+  end
+
+  return errors
+end
+
+dir = if ARGV.length == 1
+        ARGV[0]
+      else
+        "."
+      end
+errors = process_dir(dir, dir)
+errors.each do |error|
+  $stderr.puts "#{error.class}: #{error.message}"
+end

--- a/.github/actions/alpine-pandoc-hugo/delete-script.rb
+++ b/.github/actions/alpine-pandoc-hugo/delete-script.rb
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 # delete-script.rb
 # Usage: ./delete-script.rb [dir]
@@ -19,52 +20,50 @@
 
 START_MARKER = '<!-- REM'
 END_MARKER = 'REM -->'
-FILE_EXT = ".md"
+FILE_EXT = '.md'
 
 class RemSyntaxError < StandardError
 end
 
 def remove_block(path, start_line, message, end_line, initial_path)
-    scope = path.delete_suffix(File.extname path)
-    if initial_path.end_with?("/")
-        scope = scope.delete_prefix(initial_path)
-    else
-        scope = scope.delete_prefix(initial_path + "/")
+  scope = path.delete_suffix(File.extname(path))
+  scope = if initial_path.end_with?('/')
+            scope.delete_prefix(initial_path)
+          else
+            scope.delete_prefix(initial_path + '/')
+          end
+
+  commit = "rm(#{scope}): #{message}"
+
+  puts "Deleting #{path}:#{start_line + 1} - #{path}:#{end_line + 1} with commit message '#{commit}'"
+
+  lines = IO.readlines(path)
+
+  File.open(path, mode: 'w') do |f|
+    lines.each_with_index do |line, index|
+      f.write(line) if index < start_line || index > end_line
     end
+  end
 
-    commit = "rm(#{scope}): #{message}"
-
-        puts "Deleting #{path}:#{start_line + 1} - #{path}:#{end_line + 1} with commit message '#{commit}'"
-
-        lines = IO.readlines(path)
-
-    File.open(path, mode: "w") do |f|
-        lines.each_with_index do |line, index|
-            if index < start_line || index > end_line
-                f.write(line)
-            end
-        end
-    end
-
-    system("git add '#{path}'", exception: true)
-    system("git commit -m '#{commit}'", exception: true)
+  system("git add '#{path}'", exception: true)
+  system("git commit -m '#{commit}'", exception: true)
 end
 
 def process_file_once(path, initial_path)
   start_line = false
-  message = ""
+  message = ''
   end_line = false
 
   IO.readlines(path).each_with_index do |line, index|
-
     if !start_line && line.start_with?(START_MARKER)
       start_line = index
-      message = line.delete_prefix(START_MARKER + "").strip()
+      message = line.delete_prefix(START_MARKER + '').strip
     elsif start_line
       if line.start_with?(END_MARKER)
         end_line = index
       elsif line.start_with?(START_MARKER)
-        raise RemSyntaxError, "Found nested '#{START_MARKER}' at #{path}:#{index + 1}! (outer block starts at L#{start_line + 1})"
+        raise RemSyntaxError, "Found nested '#{START_MARKER}' at #{path}:#{index + 1}!"\
+          "(outer block starts at L#{start_line + 1})"
       end
     elsif line.start_with?(END_MARKER)
       raise RemSyntaxError, "Found '#{END_MARKER}' without corresponding '#{START_MARKER}' at #{path}:#{index + 1}"
@@ -77,18 +76,16 @@ def process_file_once(path, initial_path)
     raise RemSyntaxError, "Missing '#{END_MARKER}' at #{path}:EOF! (block starts at L#{start_line + 1})"
   elsif start_line && end_line
     remove_block(path, start_line, message, end_line, initial_path)
-    return true
+    true
   else
-    return false
+    false
   end
 end
 
 def process_file_all(file, initial_path)
   # process file until there are no more blocks to be removed
   deleted = true
-  while deleted
-      deleted = process_file_once(file, initial_path)
-  end
+  deleted = process_file_once(file, initial_path) while deleted
 end
 
 def process_dir(path, initial_path)
@@ -97,26 +94,26 @@ def process_dir(path, initial_path)
   Dir.each_child(path) do |entry|
     entry_path = File.join(path, entry)
 
-    if Dir.exists?(entry_path)
+    if Dir.exist?(entry_path)
       errors += process_dir(entry_path, initial_path)
     elsif File.file?(entry_path) && File.extname(entry_path) == FILE_EXT
       begin
         process_file_all(entry_path, initial_path)
-      rescue => e
+      rescue StandardError => e
         errors << e
       end
     end
   end
 
-  return errors
+  errors
 end
 
 dir = if ARGV.length == 1
         ARGV[0]
       else
-        "."
+        '.'
       end
 errors = process_dir(dir, dir)
 errors.each do |error|
-  $stderr.puts "#{error.class}: #{error.message}"
+  warn "#{error.class}: #{error.message}"
 end

--- a/Makefile
+++ b/Makefile
@@ -36,17 +36,17 @@ DOCKER_USER       = -u "$(shell id -u):$(shell id -g)"
 DOCKER_VOLUME     = -v "$(shell pwd):/data" -w "/data"
 DOCKER_TEX_VOLUME = -v "$(dir $(realpath $<)):/data" -w "/data"
 
-PANDOC = $(DOCKER_COMMAND) $(DOCKER_VOLUME)     $(DOCKER_USER) --entrypoint="pandoc" $(DOCKER_IMAGE)
-HUGO   = $(DOCKER_COMMAND) $(DOCKER_VOLUME)     $(DOCKER_USER) --entrypoint="hugo"   $(DOCKER_IMAGE)
-DOT    = $(DOCKER_COMMAND) $(DOCKER_VOLUME)     $(DOCKER_USER) --entrypoint="dot"    $(DOCKER_IMAGE)
-LATEX  = $(DOCKER_COMMAND) $(DOCKER_TEX_VOLUME) $(DOCKER_USER) --entrypoint="latex"  $(DOCKER_IMAGE)
-DELETE-SCRIPT = $(DOCKER_COMMAND) $(DOCKER_VOLUME) $(DOCKER_USER) --entrypoint="/opt/delete-script.rb" $(DOCKER_IMAGE)
+PANDOC        = $(DOCKER_COMMAND) $(DOCKER_VOLUME)     $(DOCKER_USER) --entrypoint="pandoc"                $(DOCKER_IMAGE)
+HUGO          = $(DOCKER_COMMAND) $(DOCKER_VOLUME)     $(DOCKER_USER) --entrypoint="hugo"                  $(DOCKER_IMAGE)
+DOT           = $(DOCKER_COMMAND) $(DOCKER_VOLUME)     $(DOCKER_USER) --entrypoint="dot"                   $(DOCKER_IMAGE)
+LATEX         = $(DOCKER_COMMAND) $(DOCKER_TEX_VOLUME) $(DOCKER_USER) --entrypoint="latex"                 $(DOCKER_IMAGE)
+DELETE_SCRIPT = $(DOCKER_COMMAND) $(DOCKER_VOLUME)     $(DOCKER_USER) --entrypoint="/opt/delete-script.rb" $(DOCKER_IMAGE)
 else
-PANDOC = pandoc
-HUGO   = hugo
-DOT    = dot
-LATEX  = cd $(dir $(realpath $<)) && latex
-DELETE-SCRIPT = ./.github/actions/alpine-pandoc-hugo/delete-script.rb
+PANDOC        = pandoc
+HUGO          = hugo
+DOT           = dot
+LATEX         = cd $(dir $(realpath $<)) && latex
+DELETE_SCRIPT = ./.github/actions/alpine-pandoc-hugo/delete-script.rb
 endif
 
 ## Data-Dir: Path to the Git submodule of Pandoc-Lecture
@@ -338,5 +338,5 @@ $(SLIDES_SINGLE_PDF_TARGETS): $$(filter $$(dir $$(patsubst $(SLIDES_OUTPUT_DIR)/
 
 .PHONY: delete-rem-tags
 delete-rem-tags: ## Run delete-script.rb to remove all <--REM--> blocks
-	$(DELETE-SCRIPT) $(SRC_DIR)
+	$(DELETE_SCRIPT) $(SRC_DIR)
 

--- a/Makefile
+++ b/Makefile
@@ -228,10 +228,6 @@ distclean: clean-all ## Same as clean-all
 .PHONY: clean
 clean: clean-temp ## Same as clean-temp
 
-.PHONY: clean-rem-tags
-clean-rem-tags: ## Run delete-script.rb to remove all <--REM--> blocks
-	$(DELETE-SCRIPT) $(SRC_DIR)
-
 ##@ New Elements
 
 ## Create new lecture stub based on archetype
@@ -337,3 +333,10 @@ $(SLIDES_SINGLE_PDF_TARGETS): $$(patsubst $(SLIDES_OUTPUT_DIR)/%.pdf,$(SLIDES_IN
 	$(create-folder)
 	$(PANDOC) $(PANDOC_DIRS) -d slides $< -o $@
 $(SLIDES_SINGLE_PDF_TARGETS): $$(filter $$(dir $$(patsubst $(SLIDES_OUTPUT_DIR)/%.pdf,$(SLIDES_INTERMEDIATE_DIR)/%, $$(subst _,/,$$@)))%, $(SLIDES_IMAGE_TARGETS))
+
+##@ Structure
+
+.PHONY: delete-rem-tags
+delete-rem-tags: ## Run delete-script.rb to remove all <--REM--> blocks
+	$(DELETE-SCRIPT) $(SRC_DIR)
+

--- a/Makefile
+++ b/Makefile
@@ -40,11 +40,13 @@ PANDOC = $(DOCKER_COMMAND) $(DOCKER_VOLUME)     $(DOCKER_USER) --entrypoint="pan
 HUGO   = $(DOCKER_COMMAND) $(DOCKER_VOLUME)     $(DOCKER_USER) --entrypoint="hugo"   $(DOCKER_IMAGE)
 DOT    = $(DOCKER_COMMAND) $(DOCKER_VOLUME)     $(DOCKER_USER) --entrypoint="dot"    $(DOCKER_IMAGE)
 LATEX  = $(DOCKER_COMMAND) $(DOCKER_TEX_VOLUME) $(DOCKER_USER) --entrypoint="latex"  $(DOCKER_IMAGE)
+DELETE-SCRIPT = $(DOCKER_COMMAND) $(DOCKER_VOLUME) $(DOCKER_USER) --entrypoint="/opt/delete-script.rb" $(DOCKER_IMAGE)
 else
 PANDOC = pandoc
 HUGO   = hugo
 DOT    = dot
 LATEX  = cd $(dir $(realpath $<)) && latex
+DELETE-SCRIPT = ./.github/actions/alpine-pandoc-hugo/delete-script.rb
 endif
 
 ## Data-Dir: Path to the Git submodule of Pandoc-Lecture
@@ -225,6 +227,10 @@ distclean: clean-all ## Same as clean-all
 
 .PHONY: clean
 clean: clean-temp ## Same as clean-temp
+
+.PHONY: clean-rem-tags
+clean-rem-tags: ## Run delete-script.rb to remove all <--REM--> blocks
+	$(DELETE-SCRIPT) $(SRC_DIR)
 
 ##@ New Elements
 


### PR DESCRIPTION
Implementeirt das Entfernen der
```md
<!-- REM

REM -->
```
Blöcke in den Markdown Dateien.

Zusätzlich integriert es den Aufruf als Target in der Makefile und als Teil des Docker-Image.