### PR TITLE
fix: git safe repo directory for docker image

### DIFF
--- a/.github/actions/alpine-pandoc-hugo/Dockerfile
+++ b/.github/actions/alpine-pandoc-hugo/Dockerfile
@@ -7,6 +7,4 @@ RUN apk --no-cache add ruby git
 COPY delete-script.rb /opt/delete-script.rb
 RUN chmod +x /opt/delete-script.rb
 
-RUN git config --global --add safe.directory /data
-
 ENTRYPOINT ["sh", "-c"]

--- a/.github/actions/alpine-pandoc-hugo/Dockerfile
+++ b/.github/actions/alpine-pandoc-hugo/Dockerfile
@@ -7,4 +7,6 @@ RUN apk --no-cache add ruby git
 COPY delete-script.rb /opt/delete-script.rb
 RUN chmod +x /opt/delete-script.rb
 
+RUN git config --global --add safe.directory /data
+
 ENTRYPOINT ["sh", "-c"]

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,11 @@ DOCKER_TEX_VOLUME    = -v "$(dir $(realpath $<)):$(DOCKER_REPO_MNTPOINT)" -w "$(
 # https://github.blog/2022-04-12-git-security-vulnerability-announced/ &
 # https://stackoverflow.com/questions/71901632/fatal-error-unsafe-repository-home-repon-is-owned-by-someone-else
 # for a general overview of the issue.
-DOCKER_GIT_ENV = --env GIT_DIR="$(DOCKER_REPO_MNTPOINT)/.git"
+DOCKER_GIT_ENV = --env GIT_DIR="$(DOCKER_REPO_MNTPOINT)/.git" \
+				 --env GIT_AUTHOR_NAME="$(shell git config user.name)" \
+				 --env GIT_AUTHOR_EMAIL="$(shell git config user.email)" \
+				 --env GIT_COMMITTER_NAME="$(shell git config user.name)" \
+				 --env GIT_COMMITTER_EMAIL="$(shell git config user.email)"
 
 PANDOC        = $(DOCKER_COMMAND) $(DOCKER_VOLUME)     $(DOCKER_USER) --entrypoint="pandoc"                                  $(DOCKER_IMAGE)
 HUGO          = $(DOCKER_COMMAND) $(DOCKER_VOLUME)     $(DOCKER_USER) --entrypoint="hugo"                                    $(DOCKER_IMAGE)

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ DOCKER_TEX_VOLUME    = -v "$(dir $(realpath $<)):$(DOCKER_REPO_MNTPOINT)" -w "$(
 DOCKER_GIT_ENV = --env GIT_DIR="$(DOCKER_REPO_MNTPOINT)/.git" \
 				 --env GIT_AUTHOR_NAME="$(shell git config user.name)" \
 				 --env GIT_AUTHOR_EMAIL="$(shell git config user.email)" \
-				 --env GIT_COMMITTER_NAME="$(shell git config user.name)" \
+				 --env GIT_COMMITTER_NAME="$(shell git config user.name)"   \
 				 --env GIT_COMMITTER_EMAIL="$(shell git config user.email)"
 
 PANDOC        = $(DOCKER_COMMAND) $(DOCKER_VOLUME)     $(DOCKER_USER) --entrypoint="pandoc"                                  $(DOCKER_IMAGE)

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,8 @@ ifneq ($(DOCKER), false)
 DOCKER_IMAGE      = alpine-pandoc-hugo
 DOCKER_COMMAND    = docker run --rm -i
 DOCKER_USER       = -u "$(shell id -u):$(shell id -g)"
+DOCKER_VOLUME     = -v "$(shell pwd):/data" -w "/data"
+DOCKER_TEX_VOLUME = -v "$(dir $(realpath $<)):/data" -w "/data"
 # GIT_DIR ensures that git works with the repository
 # no matter the owning user of the directory.
 # see https://github.com/Compilerbau/CB-Lecture-Bachelor/pull/16 for the discussion
@@ -42,14 +44,13 @@ DOCKER_USER       = -u "$(shell id -u):$(shell id -g)"
 # for a general overview of the issue.
 #
 # ***Important***: keep the location of GIT_DIR in sync with the mountpoint of the repository inside the container.
-DOCKER_VOLUME     = -v "$(shell pwd):/data" -w "/data" --env GIT_DIR=/data/.git
-DOCKER_TEX_VOLUME = -v "$(dir $(realpath $<)):/data" -w "/data" --env GIT_DIR=/data/.git
+DOCKER_GIT_ENV = --env GIT_DIR=/data/.git
 
-PANDOC        = $(DOCKER_COMMAND) $(DOCKER_VOLUME)     $(DOCKER_USER) --entrypoint="pandoc"                $(DOCKER_IMAGE)
-HUGO          = $(DOCKER_COMMAND) $(DOCKER_VOLUME)     $(DOCKER_USER) --entrypoint="hugo"                  $(DOCKER_IMAGE)
-DOT           = $(DOCKER_COMMAND) $(DOCKER_VOLUME)     $(DOCKER_USER) --entrypoint="dot"                   $(DOCKER_IMAGE)
-LATEX         = $(DOCKER_COMMAND) $(DOCKER_TEX_VOLUME) $(DOCKER_USER) --entrypoint="latex"                 $(DOCKER_IMAGE)
-DELETE_SCRIPT = $(DOCKER_COMMAND) $(DOCKER_VOLUME)     $(DOCKER_USER) --entrypoint="/opt/delete-script.rb" $(DOCKER_IMAGE)
+PANDOC        = $(DOCKER_COMMAND) $(DOCKER_VOLUME)     $(DOCKER_USER) --entrypoint="pandoc"                                  $(DOCKER_IMAGE)
+HUGO          = $(DOCKER_COMMAND) $(DOCKER_VOLUME)     $(DOCKER_USER) --entrypoint="hugo"                                    $(DOCKER_IMAGE)
+DOT           = $(DOCKER_COMMAND) $(DOCKER_VOLUME)     $(DOCKER_USER) --entrypoint="dot"                                     $(DOCKER_IMAGE)
+LATEX         = $(DOCKER_COMMAND) $(DOCKER_TEX_VOLUME) $(DOCKER_USER) --entrypoint="latex"                                   $(DOCKER_IMAGE)
+DELETE_SCRIPT = $(DOCKER_COMMAND) $(DOCKER_VOLUME)     $(DOCKER_USER) --entrypoint="/opt/delete-script.rb" $(DOCKER_GIT_ENV) $(DOCKER_IMAGE)
 else
 PANDOC        = pandoc
 HUGO          = hugo

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ DOCKER_REPO_MNTPOINT = /data
 DOCKER_IMAGE         = alpine-pandoc-hugo
 DOCKER_COMMAND       = docker run --rm -i
 DOCKER_USER          = -u "$(shell id -u):$(shell id -g)"
-DOCKER_VOLUME        = -v "$(shell pwd):/data" -w "$(DOCKER_REPO_MNTPOINT)"
+DOCKER_VOLUME        = -v "$(shell pwd):$(DOCKER_REPO_MNTPOINT)" -w "$(DOCKER_REPO_MNTPOINT)"
 DOCKER_TEX_VOLUME    = -v "$(dir $(realpath $<)):$(DOCKER_REPO_MNTPOINT)" -w "$(DOCKER_REPO_MNTPOINT)"
 # GIT_DIR ensures that git works with the repository
 # no matter the owning user of the directory.

--- a/Makefile
+++ b/Makefile
@@ -43,9 +43,9 @@ DOCKER_TEX_VOLUME    = -v "$(dir $(realpath $<)):$(DOCKER_REPO_MNTPOINT)" -w "$(
 # https://github.blog/2022-04-12-git-security-vulnerability-announced/ &
 # https://stackoverflow.com/questions/71901632/fatal-error-unsafe-repository-home-repon-is-owned-by-someone-else
 # for a general overview of the issue.
-DOCKER_GIT_ENV = --env GIT_DIR="$(DOCKER_REPO_MNTPOINT)/.git" \
-				 --env GIT_AUTHOR_NAME="$(shell git config user.name)" \
-				 --env GIT_AUTHOR_EMAIL="$(shell git config user.email)" \
+DOCKER_GIT_ENV = --env GIT_DIR="$(DOCKER_REPO_MNTPOINT)/.git"               \
+				 --env GIT_AUTHOR_NAME="$(shell git config user.name)"      \
+				 --env GIT_AUTHOR_EMAIL="$(shell git config user.email)"    \
 				 --env GIT_COMMITTER_NAME="$(shell git config user.name)"   \
 				 --env GIT_COMMITTER_EMAIL="$(shell git config user.email)"
 

--- a/Makefile
+++ b/Makefile
@@ -44,10 +44,10 @@ DOCKER_TEX_VOLUME    = -v "$(dir $(realpath $<)):$(DOCKER_REPO_MNTPOINT)" -w "$(
 # https://stackoverflow.com/questions/71901632/fatal-error-unsafe-repository-home-repon-is-owned-by-someone-else
 # for a general overview of the issue.
 DOCKER_GIT_ENV = --env GIT_DIR="$(DOCKER_REPO_MNTPOINT)/.git"               \
-				 --env GIT_AUTHOR_NAME="$(shell git config user.name)"      \
-				 --env GIT_AUTHOR_EMAIL="$(shell git config user.email)"    \
-				 --env GIT_COMMITTER_NAME="$(shell git config user.name)"   \
-				 --env GIT_COMMITTER_EMAIL="$(shell git config user.email)"
+                 --env GIT_AUTHOR_NAME="$(shell git config user.name)"      \
+                 --env GIT_AUTHOR_EMAIL="$(shell git config user.email)"    \
+                 --env GIT_COMMITTER_NAME="$(shell git config user.name)"   \
+                 --env GIT_COMMITTER_EMAIL="$(shell git config user.email)"
 
 PANDOC        = $(DOCKER_COMMAND) $(DOCKER_VOLUME)     $(DOCKER_USER) --entrypoint="pandoc"                                  $(DOCKER_IMAGE)
 HUGO          = $(DOCKER_COMMAND) $(DOCKER_VOLUME)     $(DOCKER_USER) --entrypoint="hugo"                                    $(DOCKER_IMAGE)

--- a/Makefile
+++ b/Makefile
@@ -33,8 +33,17 @@ ifneq ($(DOCKER), false)
 DOCKER_IMAGE      = alpine-pandoc-hugo
 DOCKER_COMMAND    = docker run --rm -i
 DOCKER_USER       = -u "$(shell id -u):$(shell id -g)"
-DOCKER_VOLUME     = -v "$(shell pwd):/data" -w "/data"
-DOCKER_TEX_VOLUME = -v "$(dir $(realpath $<)):/data" -w "/data"
+# GIT_DIR ensures that git works with the repository
+# no matter the owning user of the directory.
+# see https://github.com/Compilerbau/CB-Lecture-Bachelor/pull/16 for the discussion
+# around this specific workaround and
+# https://github.blog/2022-04-12-git-security-vulnerability-announced/ &
+# https://stackoverflow.com/questions/71901632/fatal-error-unsafe-repository-home-repon-is-owned-by-someone-else
+# for a general overview of the issue.
+#
+# ***Important***: keep the location of GIT_DIR in sync with the mountpoint of the repository inside the container.
+DOCKER_VOLUME     = -v "$(shell pwd):/data" -w "/data" --env GIT_DIR=/data/.git
+DOCKER_TEX_VOLUME = -v "$(dir $(realpath $<)):/data" -w "/data" --env GIT_DIR=/data/.git
 
 PANDOC        = $(DOCKER_COMMAND) $(DOCKER_VOLUME)     $(DOCKER_USER) --entrypoint="pandoc"                $(DOCKER_IMAGE)
 HUGO          = $(DOCKER_COMMAND) $(DOCKER_VOLUME)     $(DOCKER_USER) --entrypoint="hugo"                  $(DOCKER_IMAGE)

--- a/Makefile
+++ b/Makefile
@@ -30,11 +30,12 @@
 ## set to the folder of the current .tex file. When called directly, we
 ## need to first change-dir to this folder.
 ifneq ($(DOCKER), false)
-DOCKER_IMAGE      = alpine-pandoc-hugo
-DOCKER_COMMAND    = docker run --rm -i
-DOCKER_USER       = -u "$(shell id -u):$(shell id -g)"
-DOCKER_VOLUME     = -v "$(shell pwd):/data" -w "/data"
-DOCKER_TEX_VOLUME = -v "$(dir $(realpath $<)):/data" -w "/data"
+DOCKER_REPO_MNTPOINT = /data
+DOCKER_IMAGE         = alpine-pandoc-hugo
+DOCKER_COMMAND       = docker run --rm -i
+DOCKER_USER          = -u "$(shell id -u):$(shell id -g)"
+DOCKER_VOLUME        = -v "$(shell pwd):/data" -w "$(DOCKER_REPO_MNTPOINT)"
+DOCKER_TEX_VOLUME    = -v "$(dir $(realpath $<)):$(DOCKER_REPO_MNTPOINT)" -w "$(DOCKER_REPO_MNTPOINT)"
 # GIT_DIR ensures that git works with the repository
 # no matter the owning user of the directory.
 # see https://github.com/Compilerbau/CB-Lecture-Bachelor/pull/16 for the discussion
@@ -42,9 +43,7 @@ DOCKER_TEX_VOLUME = -v "$(dir $(realpath $<)):/data" -w "/data"
 # https://github.blog/2022-04-12-git-security-vulnerability-announced/ &
 # https://stackoverflow.com/questions/71901632/fatal-error-unsafe-repository-home-repon-is-owned-by-someone-else
 # for a general overview of the issue.
-#
-# ***Important***: keep the location of GIT_DIR in sync with the mountpoint of the repository inside the container.
-DOCKER_GIT_ENV = --env GIT_DIR=/data/.git
+DOCKER_GIT_ENV = --env GIT_DIR="$(DOCKER_REPO_MNTPOINT)/.git"
 
 PANDOC        = $(DOCKER_COMMAND) $(DOCKER_VOLUME)     $(DOCKER_USER) --entrypoint="pandoc"                                  $(DOCKER_IMAGE)
 HUGO          = $(DOCKER_COMMAND) $(DOCKER_VOLUME)     $(DOCKER_USER) --entrypoint="hugo"                                    $(DOCKER_IMAGE)


### PR DESCRIPTION
Fixes an issue introduced with a recent git update
(https://github.blog/2022-04-12-git-security-vulnerability-announced/)
with a common workaround (https://github.com/actions/checkout/pull/762,
https://stackoverflow.com/questions/71901632/fatal-error-unsafe-repository-home-repon-is-owned-by-someone-else,
https://github.com/actions/checkout/issues/760),
by marking the /data directory inside the container as safe for git
during the container build.

Fixes #17 

**Depends on #19**
