### PR TITLE
tooling(delete-rem-tags): pass git commit info

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ DOCKER_TEX_VOLUME    = -v "$(dir $(realpath $<)):$(DOCKER_REPO_MNTPOINT)" -w "$(
 # https://github.blog/2022-04-12-git-security-vulnerability-announced/ &
 # https://stackoverflow.com/questions/71901632/fatal-error-unsafe-repository-home-repon-is-owned-by-someone-else
 # for a general overview of the issue.
-DOCKER_GIT_ENV = --env GIT_DIR="$(DOCKER_REPO_MNTPOINT)/.git"
+DOCKER_GIT_ENV = --env GIT_DIR="$(DOCKER_REPO_MNTPOINT)/.git" --env GIT_AUTHOR_NAME="$(shell git config user.name)" --env GIT_AUTHOR_EMAIL="$(shell git config user.email)"
 
 PANDOC        = $(DOCKER_COMMAND) $(DOCKER_VOLUME)     $(DOCKER_USER) --entrypoint="pandoc"                                  $(DOCKER_IMAGE)
 HUGO          = $(DOCKER_COMMAND) $(DOCKER_VOLUME)     $(DOCKER_USER) --entrypoint="hugo"                                    $(DOCKER_IMAGE)

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,11 @@ DOCKER_TEX_VOLUME    = -v "$(dir $(realpath $<)):$(DOCKER_REPO_MNTPOINT)" -w "$(
 # https://github.blog/2022-04-12-git-security-vulnerability-announced/ &
 # https://stackoverflow.com/questions/71901632/fatal-error-unsafe-repository-home-repon-is-owned-by-someone-else
 # for a general overview of the issue.
-DOCKER_GIT_ENV = --env GIT_DIR="$(DOCKER_REPO_MNTPOINT)/.git" --env GIT_AUTHOR_NAME="$(shell git config user.name)" --env GIT_AUTHOR_EMAIL="$(shell git config user.email)"
+DOCKER_GIT_ENV = --env GIT_DIR="$(DOCKER_REPO_MNTPOINT)/.git" \
+				 --env GIT_AUTHOR_NAME="$(shell git config user.name)" \
+				 --env GIT_AUTHOR_EMAIL="$(shell git config user.email)" \
+				 --env GIT_COMMITTER_NAME="$(shell git config user.name)" \
+				 --env GIT_COMMITTER_EMAIL="$(shell git config user.email)"
 
 PANDOC        = $(DOCKER_COMMAND) $(DOCKER_VOLUME)     $(DOCKER_USER) --entrypoint="pandoc"                                  $(DOCKER_IMAGE)
 HUGO          = $(DOCKER_COMMAND) $(DOCKER_VOLUME)     $(DOCKER_USER) --entrypoint="hugo"                                    $(DOCKER_IMAGE)


### PR DESCRIPTION
Passes git author information via environment variables into the docker
container, in order to ensure commits done by the script have correct
author information.

Since the changes in the Makefile occur in the same position as in #16 this PR is based on the changes in #16 and currently targets the branch of #16. GitHub should automatically adjust the target branch if #16 gets merged first (although I just heard it does, I've not tried it yet).

Fixes #18 
