### PR TITLE
ILIAS 7.x: Pretty URLs won't work in HTML-Learnmodul anymore

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,4 +1,3 @@
-#baseURL: "https://compilerbau.github.io/Lecture/"
 baseURL: "https://www.fh-bielefeld.de/elearning/data/FH-Bielefeld/lm_data/lm_1360443/"
 canonifyURLs: true   # prepend all relative URLs w/ baseURL
 relativeURLs: false  # do NOT rewrite relative URLs to be relative to current content

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,8 @@
 #baseURL: "https://compilerbau.github.io/Lecture/"
 baseURL: "https://www.fh-bielefeld.de/elearning/data/FH-Bielefeld/lm_data/lm_1360443/"
-canonifyURLs: true
+canonifyURLs: true   # prepend all relative URLs w/ baseURL
+relativeURLs: false  # do NOT rewrite relative URLs to be relative to current content
+uglyurls: true       # use foo.de/bar.html instead of foo.de/bar/ (our new ILIAS 7.x HTML-Lernmodul won't find landing pages else)
 
 languageCode: "de-DE"
 metaDataFormat: "yaml"

--- a/config.yaml
+++ b/config.yaml
@@ -32,17 +32,6 @@ params:
   - "relearn-dark"
   - "green"
 
-outputs:
-  home:
-    - "HTML"
-    - "PRINT"
-  section:
-    - "HTML"
-    - "PRINT"
-  page:
-    - "HTML"
-    - "PRINT"
-
 menu:
   shortcuts:
   - name: "<i class='fas fa-bookmark'></i> Fahrplan"


### PR DESCRIPTION
Nach dem Upgrade auf ILIAS 7.x werden im HTML-Lernmodul die Landing-Pages nicht mehr gefunden. Statt `foo.de/bar/` muss man nun auf `foo.de/bar.html` zurückfallen (["ugly URLs](https://gohugo.io/content-management/urls/#ugly-urls)).

Leider funktioniert damit dann die neue [Print-Funktionalität](https://mcshelby.github.io/hugo-theme-relearn/basics/configuration/#activate-print-support) im Hugo-Relearn-Theme nicht mehr. 

Ein Issue ist Upstream eröffnet (https://github.com/McShelby/hugo-theme-relearn/issues/322).

Bis dahin ist die Lösung:
1. Ugly-URLs aktivieren (`foo.de/bar/` => `foo.de/bar.html`)
2. Kanonische URLs aktivieren (`foo.de/bar.html` => `<baseURL>/foo.de/bar.html`)
3. Relative URLs deaktivieren (kein Rewriting relativer URLs relativ zum aktuellen Content)
4. [Neue Print-Funktionalität](https://mcshelby.github.io/hugo-theme-relearn/basics/configuration/#activate-print-support) wieder entfernen


Fixes #54 